### PR TITLE
Manage 404 error in repo listing

### DIFF
--- a/jenkins_epo/procedures.py
+++ b/jenkins_epo/procedures.py
@@ -34,7 +34,12 @@ def list_repositories(with_settings=False):
         if repository in repositories:
             continue
         owner, name = repository.split('/')
-        repository = Repository.from_name(owner, name)
+        try:
+            repository = Repository.from_name(owner, name)
+        except Exception as e:
+            logger.warn("Failed to fetch repo %s: %s", repository, e)
+            continue
+
         repositories[repository] = repository
         logger.debug("Managing %s.", repository)
 
@@ -45,12 +50,11 @@ def list_repositories(with_settings=False):
             if remote in ignored_remotes:
                 continue
 
-            repository = Repository.from_remote(remote)
-            if repository not in repositories:
-                # Maybe we have the old name, so first, resolve it.
-                repository = Repository.from_name(
-                    repository.owner, repository.name
-                )
+            try:
+                repository = Repository.from_remote(remote)
+            except Exception as e:
+                logger.warn("Failed to fetch repo %s: %s", repository, e)
+                continue
 
             if repository not in repositories:
                 if SETTINGS.REPOSITORIES_AUTO:

--- a/jenkins_epo/procedures.py
+++ b/jenkins_epo/procedures.py
@@ -53,7 +53,7 @@ def list_repositories(with_settings=False):
             try:
                 repository = Repository.from_remote(remote)
             except Exception as e:
-                logger.warn("Failed to fetch repo %s: %s", repository, e)
+                logger.warn("Failed to fetch repo %s: %s", remote, e)
                 continue
 
             if repository not in repositories:

--- a/jenkins_epo/repository.py
+++ b/jenkins_epo/repository.py
@@ -63,14 +63,14 @@ class Repository(object):
     @retry(wait_fixed=15000)
     def from_name(cls, owner, name):
         data = cached_request(GITHUB.repos(owner)(name))
-        return cls.from_remote(data['clone_url'])
+        return cls(owner=data['owner']['login'], name=data['name'])
 
     @classmethod
     def from_remote(cls, remote_url):
         match = cls.remote_re.match(remote_url)
         if not match:
             raise ValueError('%r is not github' % (remote_url,))
-        return cls(**match.groupdict())
+        return cls.from_name(**match.groupdict())
 
     def __init__(self, owner, name, jobs=None):
         self.owner = owner

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -26,6 +26,22 @@ def test_list_repositories_from_envvar(JENKINS, SETTINGS, from_name):
 @patch('jenkins_epo.procedures.Repository.from_name')
 @patch('jenkins_epo.procedures.SETTINGS')
 @patch('jenkins_epo.procedures.JENKINS')
+def test_list_repositories_from_envvar_404(JENKINS, SETTINGS, from_name):
+    from jenkins_epo import procedures
+
+    JENKINS.get_jobs.return_value = []
+
+    SETTINGS.REPOSITORIES = "owner/repo1:master owner/repo1"
+    from_name.side_effect = Exception('404')
+
+    repositories = procedures.list_repositories()
+
+    assert 0 == len(list(repositories))
+
+
+@patch('jenkins_epo.procedures.Repository.from_name')
+@patch('jenkins_epo.procedures.SETTINGS')
+@patch('jenkins_epo.procedures.JENKINS')
 def test_list_repositories_with_settings(JENKINS, SETTINGS, from_name):
     from jenkins_epo import procedures
 
@@ -59,6 +75,26 @@ def test_list_repositories_from_jenkins(JENKINS, SETTINGS, from_name):
     SETTINGS.REPOSITORIES = ""
     repositories = procedures.list_repositories()
     assert 1 == len(list(repositories))
+
+
+@patch('jenkins_epo.procedures.Repository.from_name')
+@patch('jenkins_epo.procedures.SETTINGS')
+@patch('jenkins_epo.procedures.JENKINS')
+def test_list_repositories_from_jenkins_404(JENKINS, SETTINGS, from_name):
+    from jenkins_epo import procedures
+
+    from_name.side_effect = [Mock()]
+    job = Mock()
+    job.get_scm_url.return_value = ['https://github.com/owner/repo.git']
+    JENKINS.get_jobs.return_value = [job]
+
+    SETTINGS.REPOSITORIES = ""
+
+    from_name.side_effect = Exception('404')
+
+    repositories = procedures.list_repositories()
+
+    assert 0 == len(list(repositories))
 
 
 @patch('jenkins_epo.procedures.Repository.from_name')

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,16 +1,38 @@
 from datetime import datetime
 from unittest.mock import Mock, patch
 
+import pytest
+
 
 @patch('jenkins_epo.repository.cached_request')
 def test_from_name(cached_request):
     from jenkins_epo.repository import Repository
 
     cached_request.return_value = {
-        'clone_url': 'https://github.com/newowner/newname.git'
+        'owner': {'login': 'newowner'},
+        'name': 'newname',
     }
 
     repo = Repository.from_name('oldowner', 'oldname')
+    assert 'newowner' == repo.owner
+    assert 'newname' == repo.name
+
+
+@patch('jenkins_epo.repository.cached_request')
+def test_from_remote(cached_request):
+    from jenkins_epo.repository import Repository
+
+    with pytest.raises(ValueError):
+        Repository.from_remote('https://git.lan/project.git')
+
+    assert not cached_request.mock_calls
+
+    cached_request.return_value = {
+        'owner': {'login': 'newowner'},
+        'name': 'newname',
+    }
+
+    repo = Repository.from_remote('https://github.com/owner/project.git')
     assert 'newowner' == repo.owner
     assert 'newname' == repo.name
 


### PR DESCRIPTION
Fixes:

    [jenkins_epo.github          DEBUG] GET https://api.github.com/repos/owner/repo (remaining=57)
    [jenkins_epo                 ERROR] Unhandled error
    Traceback (most recent call last):
      File "/usr/local/lib/python3.4/dist-packages/jenkins_epo/github.py", line 154, in _http
        response = opener.open(request, timeout=TIMEOUT)
      File "/usr/lib/python3.4/urllib/request.py", line 461, in open
        response = meth(req, response)
      File "/usr/lib/python3.4/urllib/request.py", line 571, in http_response
        'http', request, response, code, msg, hdrs)
      File "/usr/lib/python3.4/urllib/request.py", line 499, in error
        return self._call_chain(*args)
      File "/usr/lib/python3.4/urllib/request.py", line 433, in _call_chain
        result = func(*args)
      File "/usr/lib/python3.4/urllib/request.py", line 579, in http_error_default
        raise HTTPError(req.full_url, code, msg, hdrs, fp)
    urllib.error.HTTPError: HTTP Error 404: Not Found