### PR TITLE
Watch only protected branches

### DIFF
--- a/jenkins_epo/settings.py
+++ b/jenkins_epo/settings.py
@@ -64,8 +64,7 @@ SETTINGS = EnvironmentSettings(defaults={
     'NAME': 'Jenkins GitHub Builder',
     'PR': '',
     'RATE_LIMIT_THRESHOLD': 250,
-    # List repositories and their main branches:
-    #   'owner/repo1:master owner/repo2:master,stable'
+    # List repositories: owner/repo1,owner/repo2
     'REPOSITORIES': '',
     'VERBOSE': '',
     'GITHUB_TOKEN': None,

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -12,10 +12,10 @@ def test_whoami(cached_request):
 
 @patch('jenkins_epo.procedures.Repository.from_name')
 @patch('jenkins_epo.procedures.SETTINGS')
-def test_list_repositories_from_envvar(SETTINGS, from_name):
+def test_list_repositories(SETTINGS, from_name):
     from jenkins_epo import procedures
 
-    SETTINGS.REPOSITORIES = "owner/repo1:master owner/repo1"
+    SETTINGS.REPOSITORIES = "owner/repo1,owner/repo1"
     repositories = procedures.list_repositories()
     assert 1 == len(list(repositories))
 
@@ -25,52 +25,12 @@ def test_list_repositories_from_envvar(SETTINGS, from_name):
 def test_list_repositories_from_envvar_404(SETTINGS, from_name):
     from jenkins_epo import procedures
 
-    SETTINGS.REPOSITORIES = "owner/repo1:master owner/repo1"
+    SETTINGS.REPOSITORIES = "owner/repo1 owner/repo1"
     from_name.side_effect = Exception('404')
 
     repositories = procedures.list_repositories()
 
     assert 0 == len(list(repositories))
-
-
-@patch('jenkins_epo.procedures.Repository.from_name')
-@patch('jenkins_epo.procedures.SETTINGS')
-def test_list_repositories_with_settings(SETTINGS, from_name):
-    from jenkins_epo import procedures
-
-    from_name.side_effect = reps = [Mock(), Mock()]
-    reps[0].__str__ = lambda x: 'owner/repo1'
-    reps[1].__str__ = lambda x: 'owner/repo2'
-
-    SETTINGS.REPOSITORIES = "owner/repo1:master,stable owner/repo2"
-    repositories = {
-        str(p): p
-        for p in procedures.list_repositories(with_settings=True)
-    }
-    assert 2 == len(list(repositories))
-    assert 'owner/repo1' in repositories
-    assert reps[0].load_settings.mock_calls
-    assert 'owner/repo2' in repositories
-    assert reps[1].load_settings.mock_calls
-
-
-@patch('jenkins_epo.procedures.Repository.from_name')
-@patch('jenkins_epo.procedures.SETTINGS')
-def test_list_repositories_with_settings_fails(SETTINGS, from_name):
-    from jenkins_epo import procedures
-
-    from_name.return_value = repo = Mock()
-    repo.__str__ = lambda x: 'owner/repo1'
-    repo.load_settings.side_effect = Exception('POUET')
-
-    SETTINGS.REPOSITORIES = "owner/repo1"
-    repositories = {
-        str(p): p
-        for p in procedures.list_repositories(with_settings=True)
-    }
-
-    assert 0 == len(list(repositories))
-    assert repo.load_settings.mock_calls
 
 
 @patch('jenkins_epo.procedures.list_repositories')
@@ -80,21 +40,24 @@ def test_iter_heads(list_repositories):
     a = Mock()
     branch = Mock(token='a/branch')
     branch.sort_key.return_value = False, 100, 'master'
-    a.load_branches.return_value = [branch]
+    a.process_protected_branches.return_value = [branch]
     pr = Mock(token='a/pr')
     pr.sort_key.return_value = False, 50, 'feature'
-    a.load_pulls.return_value = [pr]
+    a.process_pull_requests.return_value = [pr]
     b = Mock()
     branch = Mock(token='b/branch')
     branch.sort_key.return_value = False, 100, 'master'
-    b.load_branches.return_value = [branch]
+    b.process_protected_branches.return_value = [branch]
     pr1 = Mock(token='b/pr1')
     pr1.sort_key.return_value = False, 50, 'feature'
     pr2 = Mock(token='b/pr2')
     pr2.sort_key.return_value = True, 50, 'hotfix'
-    b.load_pulls.return_value = [pr1, pr2]
+    b.process_pull_requests.return_value = [pr1, pr2]
+    c = Mock()
+    c.process_protected_branches.return_value = []
+    c.process_pull_requests.return_value = []
 
-    list_repositories.return_value = [a, b]
+    list_repositories.return_value = [a, b, c]
 
     computed = [h.token for h in iter_heads()]
     wanted = ['a/branch', 'b/pr2', 'a/pr', 'b/branch', 'b/pr1']


### PR DESCRIPTION
Avec cette PR:

- les PR urgentes sont testées avant les branches protégées
- on lance le premier commit à tester dès qu'on l'a, sans avoir chargé les autres projets (environ 5s après le démarrage)
- on se contente de demander à GitHub les branches protégée, ça sert à rien de reconfigurer ça.