### PR TITLE
Autocancel build from Jenkins

### DIFF
--- a/jenkins_epo/extensions/jenkins.py
+++ b/jenkins_epo/extensions/jenkins.py
@@ -13,6 +13,7 @@
 # jenkins-epo.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections import OrderedDict
+from datetime import datetime, timedelta
 import logging
 import re
 
@@ -20,7 +21,7 @@ from jenkinsapi.custom_exceptions import UnknownJob
 
 from ..bot import Extension, Error
 from ..jenkins import JENKINS
-from ..repository import CommitStatus
+from ..repository import Commit, CommitStatus
 from ..utils import match
 
 
@@ -171,6 +172,51 @@ jenkins: reset-skip-errors
                 'state': 'pending',
             })
         return new_status
+
+
+class AutoCancelExtension(JenkinsExtension):
+    stage = '10'
+
+    def run(self):
+        now = datetime.now()
+        maxage = timedelta(hours=4)
+        current_sha = self.current.last_commit.sha
+        for name, job in self.current.jobs.items():
+            if not job.is_running():
+                continue
+
+            for id_ in job.get_build_ids():
+                build = job.get_build(id_)
+                if not build.is_running():
+                    continue
+
+                seconds = build._data['timestamp'] / 1000.
+                build_age = now - datetime.fromtimestamp(seconds)
+                if build_age > maxage:
+                    break
+
+                branch = (
+                    build.get_revision_branch()[0]['name']
+                    .replace('origin/', '')
+                )
+                if branch != self.current.head.ref:
+                    continue
+
+                building_sha = build.get_revision()
+                if building_sha == current_sha:
+                    continue
+
+                commit = Commit(
+                    self.current.head.repository,
+                    building_sha,
+                )
+                status = CommitStatus(
+                    context=job.name,
+                    target_url=build._data['url'],
+                    state='pending',
+                )
+                logger.info("Queuing %s for cancel.", build)
+                self.current.cancel_queue.append((commit, status))
 
 
 class CancellerExtension(JenkinsExtension):

--- a/jenkins_epo/extensions/jenkins.py
+++ b/jenkins_epo/extensions/jenkins.py
@@ -206,8 +206,11 @@ class CancellerExtension(JenkinsExtension):
                     status, state='error', description="Build not on Jenkins."
                 )
             elif cancel and build.is_running():
-                logger.warn("Cancelling %s.", build)
-                build.stop()
+                if self.current.SETTINGS.DRY_RUN:
+                    logger.warn("Would cancelling %s.", build)
+                else:
+                    logger.warn("Cancelling %s.", build)
+                    build.stop()
                 new_status = status.__class__(
                     status, state='error', description='Cancelled after push.'
                 )

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
             'error = jenkins_epo.extensions.core:ErrorExtension',
             'help = jenkins_epo.extensions.core:HelpExtension',
             'autocancel = jenkins_epo.extensions.core:AutoCancelExtension',
+            'jenkins-autocancel = jenkins_epo.extensions.jenkins:AutoCancelExtension',  # noqa
             'jenkins-builder = jenkins_epo.extensions.jenkins:BuilderExtension',  # noqa
             'jenkins-canceller = jenkins_epo.extensions.jenkins:CancellerExtension',  # noqa
             'jenkins-createjobs = jenkins_epo.extensions.jenkins:CreateJobsExtension',  # noqa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,5 +14,6 @@ def SETTINGS():
     patcher = patch.dict('jenkins_epo.settings.SETTINGS', DEFAULTS)
     patcher.start()
     SETTINGS.DEBUG = 0
+    SETTINGS.DRY_RUN = 0
     yield SETTINGS
     patcher.stop()

--- a/tests/extensions/test_autocancel.py
+++ b/tests/extensions/test_autocancel.py
@@ -1,0 +1,137 @@
+from unittest.mock import Mock
+
+
+def test_jenkins_skip_job_not_running():
+    from jenkins_epo.extensions.jenkins import AutoCancelExtension
+
+    ext = AutoCancelExtension('test', Mock())
+    ext.current = ext.bot.current
+    ext.current.cancel_queue = []
+    ext.current.jobs = {}
+    ext.current.jobs['job'] = job = Mock()
+    job.is_running.return_value = False
+
+    ext.run()
+
+    assert job.is_running.mock_calls
+    assert 0 == len(ext.current.cancel_queue)
+
+
+def test_jenkins_skip_build_not_running():
+    from jenkins_epo.extensions.jenkins import AutoCancelExtension
+
+    ext = AutoCancelExtension('test', Mock())
+    ext.current = ext.bot.current
+    ext.current.cancel_queue = []
+    ext.current.jobs = {}
+    ext.current.jobs['job'] = job = Mock()
+    job.is_running.return_value = True
+    job.get_build_ids.return_value = [1]
+    build = job.get_build.return_value
+    build.is_running.return_value = False
+
+    ext.run()
+
+    assert job.is_running.mock_calls
+    assert 0 == len(ext.current.cancel_queue)
+
+
+def test_jenkins_skip_outdated():
+    from time import time
+    from jenkins_epo.extensions.jenkins import AutoCancelExtension
+
+    ext = AutoCancelExtension('test', Mock())
+    ext.current = ext.bot.current
+    ext.current.cancel_queue = []
+    ext.current.jobs = {}
+
+    ext.current.jobs['job'] = job = Mock()
+    job.is_running.return_value = True
+    job.get_build_ids.return_value = [1]
+    build = job.get_build.return_value
+    build.is_running.return_value = True
+    build._data = {'timestamp': (time() - 7 * 3600) * 1000}
+
+    ext.run()
+
+    assert job.is_running.mock_calls
+    assert build.is_running.mock_calls
+    assert 0 == len(ext.current.cancel_queue)
+
+
+def test_jenkins_skip_other_branch():
+    from time import time
+    from jenkins_epo.extensions.jenkins import AutoCancelExtension
+
+    ext = AutoCancelExtension('test', Mock())
+    ext.current = ext.bot.current
+    ext.current.cancel_queue = []
+    ext.current.jobs = {}
+    ext.current.head.ref = 'branch'
+
+    ext.current.jobs['job'] = job = Mock()
+    job.is_running.return_value = True
+    job.get_build_ids.return_value = [1]
+    build = job.get_build.return_value
+    build.is_running.return_value = True
+    build._data = {'timestamp': time() * 1000}
+    build.get_revision_branch.return_value = [{'name': 'origin/other'}]
+
+    ext.run()
+
+    assert job.is_running.mock_calls
+    assert build.is_running.mock_calls
+    assert build.get_revision_branch.mock_calls
+    assert 0 == len(ext.current.cancel_queue)
+
+
+def test_jenkins_skip_current_sha():
+    from time import time
+    from jenkins_epo.extensions.jenkins import AutoCancelExtension
+
+    ext = AutoCancelExtension('test', Mock())
+    ext.current = ext.bot.current
+    ext.current.cancel_queue = []
+    ext.current.jobs = {}
+    ext.current.head.ref = 'branch'
+    ext.current.last_commit.sha = 'bab1'
+    ext.current.jobs['job'] = job = Mock()
+    job.is_running.return_value = True
+    job.get_build_ids.return_value = [1]
+    build = job.get_build.return_value
+    build.is_running.return_value = True
+    build._data = {'timestamp': time() * 1000}
+    build.get_revision_branch.return_value = [{'name': 'origin/branch'}]
+    build.get_revision.return_value = 'bab1'
+
+    ext.run()
+
+    assert job.is_running.mock_calls
+    assert 0 == len(ext.current.cancel_queue)
+
+
+def test_jenkins_cancel():
+    from time import time
+    from jenkins_epo.extensions.jenkins import AutoCancelExtension
+
+    ext = AutoCancelExtension('test', Mock())
+    ext.current = ext.bot.current
+    ext.current.cancel_queue = []
+    ext.current.jobs = {}
+    ext.current.head.ref = 'branch'
+    ext.current.last_commit.sha = 'bab1'
+    ext.current.jobs['job'] = job = Mock()
+    job.is_running.return_value = True
+    job.get_build_ids.return_value = [1]
+    build = job.get_build.return_value
+    build.is_running.return_value = True
+    build._data = {
+        'url': 'jenkins://running/1',
+        'timestamp': time() * 1000,
+    }
+    build.get_revision_branch.return_value = [{'name': 'origin/branch'}]
+    build.get_revision.return_value = '01d'
+    ext.run()
+
+    assert job.is_running.mock_calls
+    assert 1 == len(ext.current.cancel_queue)

--- a/tests/extensions/test_jenkins.py
+++ b/tests/extensions/test_jenkins.py
@@ -295,6 +295,7 @@ def test_cancel_build_running(JENKINS):
     ext.current.cancel_queue = [
         (commit, CommitStatus(context='job', target_url='jenkins://job/1')),
     ]
+    ext.current.SETTINGS.DRY_RUN = 0
 
     build = JENKINS.get_build_from_url.return_value
     build.get_status.return_value = None

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,7 @@ setenv =
     EPO_CACHE_PATH=.epo-test
 commands =
     pip --disable-pip-version-check install -e .[test]
-    py.test -vvvv --strict --showlocals --junit-xml={env:CIRCLE_TEST_REPORTS:.}/junit.xml --cov=jenkins_epo tests/
-    # Workaround codecov xml report generation
-    coverage xml
+    py.test -vvvv --strict --showlocals --junit-xml={env:CIRCLE_TEST_REPORTS:.}/junit.xml --cov=jenkins_epo --cov-report=xml tests/
 
 [testenv:lint]
 basepython = python3.4


### PR DESCRIPTION
On forced push, EPO can't find a running build of lost commits. Query Jenkins for running builds and kill any build on other commit than HEAD.