### PR TITLE
Split skip out of builder

### DIFF
--- a/jenkins_epo/repository.py
+++ b/jenkins_epo/repository.py
@@ -64,6 +64,14 @@ class CommitStatus(dict):
         return True
 
     @property
+    def is_running(self):
+        if self.is_queueable:
+            return False
+        if self.get('state') == 'pending':
+            return True
+        return False
+
+    @property
     def is_rebuildable(self):
         if self.get('state') in {'error', 'failure'}:
             return True

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             'merger = jenkins_epo.extensions.core:MergerExtension',
             'outdated = jenkins_epo.extensions.core:OutdatedExtension',
             'report = jenkins_epo.extensions.core:ReportExtension',
+            'skip = jenkins_epo.extensions.core:SkipExtension',
             'yaml = jenkins_epo.extensions.core:YamlExtension'
         ],
     },

--- a/tests/extensions/test_jenkins.py
+++ b/tests/extensions/test_jenkins.py
@@ -1,36 +1,6 @@
 from unittest.mock import Mock, patch
 
 
-def test_compute_skip_null():
-    from jenkins_epo.bot import Instruction
-    from jenkins_epo.extensions.jenkins import BuilderExtension
-
-    ext = BuilderExtension('ext', Mock())
-    ext.current = ext.bot.current
-    ext.process_instruction(Instruction(author='b', name='skip'))
-    skip = [re.pattern for re in ext.current.skip]
-    assert skip == list(BuilderExtension.SKIP_ALL)
-
-
-def test_compute_skip():
-    from jenkins_epo.bot import Instruction
-    from jenkins_epo.extensions.jenkins import BuilderExtension
-
-    ext = BuilderExtension('ext', Mock())
-    ext.current = ext.bot.current
-    ext.process_instruction(Instruction(author='a', name='skip'))
-    skip = [re.pattern for re in ext.current.skip]
-    assert skip == list(BuilderExtension.SKIP_ALL)
-
-    ext.process_instruction(Instruction(author='b', name='skip'))
-    ext.process_instruction(
-        Instruction(author='b', name='skip', args=['this'])
-    )
-
-    skip = [re.pattern for re in ext.current.skip]
-    assert skip == ['this']
-
-
 def test_compute_rebuild():
     from jenkins_epo.bot import Instruction
     from jenkins_epo.extensions.jenkins import BuilderExtension
@@ -59,8 +29,6 @@ def test_build_queue_full(JENKINS):
     ext.current.job_specs = {'job': spec}
     ext.current.jobs = {'job': job}
     ext.current.statuses = {}
-    ext.current.skip = []
-    ext.current.skip_errors = []
 
     JENKINS.is_queue_empty.return_value = False
 
@@ -89,8 +57,6 @@ def test_build_queue_empty(JENKINS):
     ext.current.job_specs = {'job': spec}
     ext.current.jobs = {'job': job}
     ext.current.statuses = {}
-    ext.current.skip = []
-    ext.current.skip_errors = []
 
     JENKINS.is_queue_empty.return_value = True
 
@@ -118,8 +84,6 @@ def test_build_failed():
     ext.current.job_specs = {'job': spec}
     ext.current.jobs = {'job': job}
     ext.current.statuses = {}
-    ext.current.skip = []
-    ext.current.skip_errors = []
 
     ext.run()
 
@@ -132,7 +96,6 @@ def test_builder_ignore_perioddc():
 
     ext = BuilderExtension('b', Mock())
     ext.current = ext.bot.current
-    ext.current.skip_errors = []
     spec = Mock()
     spec.name = 'job'
     spec.config = dict(periodic=True)
@@ -140,97 +103,6 @@ def test_builder_ignore_perioddc():
     ext.current.job_specs = {'job': spec}
 
     ext.run()
-
-
-def test_match_mixed():
-    from jenkins_epo.extensions.jenkins import BuilderExtension
-    from jenkins_epo.bot import Instruction
-
-    ext = BuilderExtension('b', Mock())
-    ext.current = ext.bot.current
-    ext.current.skip = []
-    ext.process_instruction(
-        Instruction(author='epo', name='jobs', args=['-toto*', 'not*'])
-    )
-
-    assert ext.skip('toto-doc')
-    assert not ext.skip('notthis')
-
-
-def test_match_negate():
-    from jenkins_epo.extensions.jenkins import BuilderExtension
-    from jenkins_epo.bot import Instruction
-
-    ext = BuilderExtension('b', Mock())
-    ext.current = ext.bot.current
-    ext.current.skip = []
-    ext.process_instruction(
-        Instruction(author='epo', name='jobs', args=['*', '-skip*'])
-    )
-
-    assert ext.skip('skip')
-    assert not ext.skip('new')
-
-
-def test_skip_re():
-    from jenkins_epo.extensions.jenkins import BuilderExtension
-    from jenkins_epo.bot import Instruction
-
-    ext = BuilderExtension('builder', Mock())
-    ext.current = ext.bot.current
-    ext.current.jobs_match = []
-    ext.current.skip = []
-    ext.process_instruction(
-        Instruction(author='epo', name='skip', args=['toto.*', '(?!notthis)']),
-    )
-    assert ext.skip('toto-doc')
-    assert not ext.skip('notthis')
-
-
-def test_skip_re_wrong():
-    from jenkins_epo.extensions.jenkins import BuilderExtension
-    from jenkins_epo.bot import Instruction
-
-    ext = BuilderExtension('builder', Mock())
-    ext.current = ext.bot.current
-    ext.current.skip = []
-    ext.current.jobs_match = []
-    ext.current.job_specs = {}
-    ext.current.skip_errors = []
-    ext.process_instruction(
-        Instruction(author='epo', name='skip', args=['*toto)']),
-    )
-    assert not ext.skip('toto')
-    assert ext.current.skip_errors
-    ext.run()
-    assert ext.current.head.comment.mock_calls
-
-
-def test_skip_disabled_job():
-    from jenkins_epo.extensions.jenkins import BuilderExtension
-
-    ext = BuilderExtension('builder', Mock())
-    ext.current = ext.bot.current
-    job = Mock()
-    job.is_enabled.return_value = False
-    spec = Mock()
-    spec.name = 'job-disabled'
-    spec.config = dict()
-    ext.current.jobs_match = []
-    ext.current.skip = []
-    ext.current.skip_errors = []
-    ext.current.job_specs = {'job-disabled': spec}
-    ext.current.jobs = {'job-disabled': job}
-    ext.current.head.ref = 'refs/heads/pr'
-    ext.current.last_commit.filter_not_built_contexts.return_value = [
-        'job-disabled']
-    ext.current.last_commit.maybe_update_status.return_value = {
-        'description': 'Disabled',
-    }
-
-    ext.run()
-
-    assert not job.build.mock_calls
 
 
 def test_only_branches():
@@ -247,7 +119,6 @@ def test_only_branches():
     ext.current.jobs = {'job': job}
     ext.current.head.filter_not_built_contexts.return_value = ['job']
     ext.current.head.ref = 'refs/heads/pr'
-    ext.current.skip_errors = []
 
     ext.run()
 


### PR DESCRIPTION
This make skip logic independant of Jenkins and simplify builder extension.

- As a regression, `skip: REGEXP` is dropped. 
- `skip` is still supported and skips all jobs.
- `jobs: GLOB` overwrite previous `skip`.
- Pending builds are cancelled when skipped.

cc @toopy @jpic @zebuline 

```
$ jenkins-epo list-extensions
00 outdated
00 yaml
05 jenkins-createjobs
10 autocancel
10 jenkins-autocancel
10 skip
20 jenkins-canceller
30 jenkins-stages
50 jenkins-builder
90 help
90 merger
90 report
99 error
```