### PR TITLE
Fix PR description instruction date

### DIFF
--- a/jenkins_epo/bot.py
+++ b/jenkins_epo/bot.py
@@ -205,6 +205,10 @@ See `jenkins: help` for documentation.
 
     def process_instructions(self, comments):
         for instruction in self.parse_instructions(comments):
+            logger.debug(
+                "Processing instruction %s from %s at %s.",
+                instruction, instruction.author, instruction.date,
+            )
             for ext in self.extensions:
                 ext.process_instruction(instruction)
 

--- a/jenkins_epo/repository.py
+++ b/jenkins_epo/repository.py
@@ -516,8 +516,11 @@ class PullRequest(Head):
         GITHUB.repos(self.repository).git.refs.heads(self.ref).delete()
 
     def list_comments(self):
+        # PR updated_at match the latest change of PR, not the date of edition
+        # of the description. So, fall back to creation date.
+        description = dict(self.payload, updated_at=self.payload['created_at'])
         issue = GITHUB.repos(self.repository).issues(self.payload['number'])
-        return [self.payload] + cached_request(issue.comments)
+        return [description] + cached_request(issue.comments)
 
     @retry
     def merge(self, message=None):

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -289,6 +289,20 @@ def test_pr_fetch_previous_commits(cached_request):
 
 
 @patch('jenkins_epo.repository.cached_request')
+def test_pr_list_comments(cached_request):
+    from jenkins_epo.repository import PullRequest
+
+    cached_request.return_value = []
+    pr = PullRequest(Mock(), dict(
+        created_at='2017-01-20 11:08:43Z',
+        number=204,
+        head=dict(ref='pr', sha='d0d0cafe', label='owner:pr'),
+    ))
+    comments = pr.list_comments()
+    assert 1 == len(comments)
+
+
+@patch('jenkins_epo.repository.cached_request')
 def test_process_commits(cached_request):
     from jenkins_epo.repository import Repository
 


### PR DESCRIPTION
Ça provoque une régression : les erreurs dans les éditions du yaml de PR sont ignorées, après la première erreur :(