### PR TITLE
Command to process one URL

### DIFF
--- a/jenkins_epo/main.py
+++ b/jenkins_epo/main.py
@@ -103,10 +103,10 @@ def list_heads():
 
 
 @asyncio.coroutine
-def run_async(command_func):
+def run_async(command_func, *args, **kwargs):
     me = asyncio.Task.current_task()
     try:
-        yield from command_func()
+        yield from command_func(*args, **kwargs)
     except BaseException:
         # Hide ^C in terminal
         sys.stderr.write('\r')
@@ -124,16 +124,25 @@ def run_async(command_func):
         raise
 
 
+def addcommand(subparsers, command):
+    parser = subparsers.add_parser(
+        command.__name__.replace('_', '-'),
+        help=inspect.cleandoc(command.__doc__ or '').split('\n')[0],
+    )
+    parser.set_defaults(command_func=command)
+    argnames = command.__code__.co_varnames[:command.__code__.co_argcount]
+    for var in argnames:
+        parser.add_argument(
+            var, metavar=var.upper(), type=str
+        )
+
+
 def main(argv=None, *, loop=None):
     argv = argv or sys.argv
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='command', metavar='COMMAND')
-    for command in [bot, list_extensions, list_heads]:
-        subparser = subparsers.add_parser(
-            command.__name__.replace('_', '-'),
-            help=inspect.cleandoc(command.__doc__ or '').split('\n')[0],
-        )
-        subparser.set_defaults(command_func=command)
+    for command in bot, list_extensions, list_heads:
+        addcommand(subparsers, command)
 
     args = parser.parse_args(argv)
     try:
@@ -141,7 +150,13 @@ def main(argv=None, *, loop=None):
     except AttributeError:
         command_func = parser.print_usage
 
+    kwargs = {
+        k: v
+        for k, v in args._get_kwargs()
+        if k not in {'command', 'command_func'}
+    }
+
     if asyncio.iscoroutinefunction(command_func):
-        WatchDog().run(run_async, command_func)
+        WatchDog().run(run_async, command_func, **kwargs)
     else:
-        command_func()
+        command_func(**kwargs)

--- a/jenkins_epo/main.py
+++ b/jenkins_epo/main.py
@@ -56,8 +56,6 @@ def loop(wrapped):
 @asyncio.coroutine
 def bot():
     """Poll GitHub to find something to do"""
-    task = asyncio.Task.current_task()
-    task.logging_id = 'bot'
     me = yield from procedures.whoami()
     loop = asyncio.get_event_loop()
 
@@ -111,6 +109,7 @@ def process(url):
 @asyncio.coroutine
 def run_async(command_func, *args, **kwargs):
     me = asyncio.Task.current_task()
+    me.logging_id = 'cmd'
     try:
         yield from command_func(*args, **kwargs)
     except BaseException:

--- a/jenkins_epo/main.py
+++ b/jenkins_epo/main.py
@@ -103,6 +103,12 @@ def list_heads():
 
 
 @asyncio.coroutine
+def process(url):
+    """Process one head"""
+    yield from procedures.process_url(url)
+
+
+@asyncio.coroutine
 def run_async(command_func, *args, **kwargs):
     me = asyncio.Task.current_task()
     try:
@@ -141,7 +147,7 @@ def main(argv=None, *, loop=None):
     argv = argv or sys.argv
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='command', metavar='COMMAND')
-    for command in bot, list_extensions, list_heads:
+    for command in bot, list_extensions, list_heads, process:
         addcommand(subparsers, command)
 
     args = parser.parse_args(argv)

--- a/jenkins_epo/procedures.py
+++ b/jenkins_epo/procedures.py
@@ -20,7 +20,7 @@ import logging
 
 from .bot import Bot
 from .github import GITHUB, cached_arequest
-from .repository import Repository, UnauthorizedRepository
+from .repository import Head, Repository, UnauthorizedRepository
 from .settings import SETTINGS
 from .utils import retry
 
@@ -115,6 +115,13 @@ def process_head(head, me=None):
 
     logger.info("Processed %s.", head)
     del task.logging_id
+
+
+@asyncio.coroutine
+def process_url(url):
+    me = yield from whoami()
+    head = yield from Head.from_url(url)
+    yield from process_head(head, me)
 
 
 @asyncio.coroutine

--- a/jenkins_epo/watchdog.py
+++ b/jenkins_epo/watchdog.py
@@ -89,5 +89,6 @@ class WatchDog(object):
                 coro = self.wrapper(callable_, *args, **kwargs)
                 try:
                     loop.run_until_complete(coro)
+                    break
                 except (CancelledError, RuntimeError):
                     pass

--- a/tests/test_head.py
+++ b/tests/test_head.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from asynctest import CoroutineMock
+import pytest
+
+
+@pytest.mark.asyncio
+@asyncio.coroutine
+def test_wrong_url(mocker):
+    from jenkins_epo.repository import Head
+
+    with pytest.raises(Exception):
+        yield from Head.from_url('https://github.com/owner/name')
+
+
+@pytest.mark.asyncio
+@asyncio.coroutine
+def test_branch_from_url(mocker):
+    mocker.patch('jenkins_epo.repository.cached_arequest', CoroutineMock())
+    mocker.patch('jenkins_epo.repository.Repository')
+    Branch = mocker.patch('jenkins_epo.repository.Branch')
+
+    from jenkins_epo.repository import Head
+
+    head = yield from Head.from_url('https://github.com/own/name/tree/master')
+    assert head == Branch.return_value
+
+
+@pytest.mark.asyncio
+@asyncio.coroutine
+def test_pr_from_url(mocker):
+    mocker.patch('jenkins_epo.repository.cached_arequest', CoroutineMock())
+    mocker.patch('jenkins_epo.repository.Repository')
+    PullRequest = mocker.patch('jenkins_epo.repository.PullRequest')
+
+    from jenkins_epo.repository import Head
+
+    head = yield from Head.from_url('https://github.com/own/name/pull/1')
+    assert head == PullRequest.return_value

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ def test_main():
 def test_main_sync(mocker):
     command = mocker.patch('jenkins_epo.main.bot')
     command.__name__ = 'bot'
+    command.__code__ = Mock(co_varnames=(), co_argcount=0)
     command._is_coroutine = None
     from jenkins_epo.main import main
 
@@ -28,6 +29,7 @@ def test_main_sync(mocker):
 def test_main_async(mocker, event_loop):
     command = mocker.patch('jenkins_epo.main.bot', CoroutineMock())
     command.__name__ = 'bot'
+    command.__code__ = Mock(co_varnames=(), co_argcount=0)
     from jenkins_epo.main import main
 
     main(argv=['bot'], loop=event_loop)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -70,3 +70,16 @@ def test_list_extensions():
     from jenkins_epo.main import list_extensions
 
     list_extensions()
+
+
+@pytest.mark.asyncio
+@asyncio.coroutine
+def test_process(mocker):
+    process_url = mocker.patch(
+        'jenkins_epo.main.procedures.process_url', CoroutineMock(),
+    )
+    from jenkins_epo.main import process
+
+    yield from process('http:///')
+
+    assert process_url.mock_calls

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -266,3 +266,20 @@ def test_throttling_compute(SETTINGS):
     )
 
     assert seconds > 0  # Chill !
+
+
+@pytest.mark.asyncio
+@asyncio.coroutine
+def test_process_url(mocker):
+    mod = 'jenkins_epo.procedures'
+    whoami = mocker.patch(mod + '.whoami', CoroutineMock())
+    from_url = mocker.patch(mod + '.Head.from_url', CoroutineMock())
+    process_head = mocker.patch(mod + '.process_head', CoroutineMock())
+
+    from jenkins_epo.procedures import process_url
+
+    yield from process_url('https//github/owner/name/pull/1')
+
+    assert whoami.mock_calls
+    assert from_url.mock_calls
+    assert process_head.mock_calls


### PR DESCRIPTION
A first step toward webhook : the ability to process a head from it's URL. This allow Jenkins to notify EPO to process on HEAD at end for build.