### PR TITLE
Preset build status from Jenkins

### DIFF
--- a/jenkins_epo/extensions/jenkins.py
+++ b/jenkins_epo/extensions/jenkins.py
@@ -159,7 +159,7 @@ class AutoCancelExtension(JenkinsExtension):
                 try:
                     jenkins_fullref = build.get_revision_branch()[0]['name']
                 except IndexError:
-                    logger.warn("Can't get revision of build %s.", build)
+                    logger.debug("Can't get revision of build %s yet.", build)
                     continue
 
                 match = self.ref_re.match(jenkins_fullref)

--- a/jenkins_epo/extensions/jenkins.py
+++ b/jenkins_epo/extensions/jenkins.py
@@ -132,24 +132,69 @@ class AutoCancelExtension(JenkinsExtension):
 
     ref_re = re.compile(r'.*origin/(?P<ref>.*)')
 
+    def compute_build_ref_and_sha(self, job, build):
+        try:
+            jenkins_fullref = build.get_revision_branch()[0]['name']
+        except IndexError:
+            for action in build._data['actions']:
+                if 'parameters' in action:
+                    break
+            else:
+                return
+            for parameter in action['parameters']:
+                if parameter['name'] == job.revision_param:
+                    break
+            else:
+                return
+            return (
+                parameter['value'][len('refs/heads/'):],
+                self.current.last_commit.sha
+            )
+        else:
+            match = self.ref_re.match(jenkins_fullref)
+            if not match:
+                return
+            return (
+                match.group('ref'),
+                build.get_revision()
+            )
+
+    def iter_preset_statuses(self, contextes, build):
+        for context in contextes:
+            default_status = CommitStatus(
+                context=context, state='pending', description='Backed',
+            )
+            status = self.current.statuses.get(
+                context, default_status,
+            )
+            if status.is_queueable:
+                status = status.from_build(build)
+                yield status
+
+    def is_build_old(self, build, now, maxage):
+        seconds = build._data['timestamp'] / 1000.
+        build_date = datetime.fromtimestamp(seconds)
+        build_age = now - build_date
+        if build_date > now:
+            logger.warning(
+                "Build %s in the future. Is timezone correct?", build
+            )
+            return False
+        return build_age > maxage
+
     @asyncio.coroutine
     def run(self):
         now = datetime.now()
         maxage = timedelta(hours=2)
         current_sha = self.current.last_commit.sha
         logger.info("Polling running builds on Jenkins.")
-        for name, job in self.current.jobs.items():
+        for name, spec in self.current.job_specs.items():
+            job = self.current.jobs[name]
+            contextes = job.list_contexts(spec)
             for build in reversed(list(job.get_builds())):
                 build.poll()
                 yield from switch_coro()
-                seconds = build._data['timestamp'] / 1000.
-                build_date = datetime.fromtimestamp(seconds)
-                build_age = now - build_date
-                if build_date > now:
-                    logger.warning(
-                        "Build %s in the future. Is timezone correct?", build
-                    )
-                elif build_age > maxage:
+                if self.is_build_old(build, now, maxage):
                     logger.debug("Stopping build iteration for older builds.")
                     break
 
@@ -157,32 +202,33 @@ class AutoCancelExtension(JenkinsExtension):
                     continue
 
                 try:
-                    jenkins_fullref = build.get_revision_branch()[0]['name']
-                except IndexError:
-                    logger.debug("Can't get revision of build %s yet.", build)
+                    build_ref, build_sha = (
+                        self.compute_build_ref_and_sha(job, build)
+                    )
+                except TypeError:
+                    logger.debug(
+                        "Can't infer build ref and sha for %s.", build,
+                    )
                     continue
 
-                match = self.ref_re.match(jenkins_fullref)
-                if not match:
-                    logger.warn("Can't infer ref from %s.", jenkins_fullref)
-                    continue
-                jenkins_ref = match.group('ref')
-                if jenkins_ref != self.current.head.ref:
+                if build_ref != self.current.head.ref:
                     continue
 
-                building_sha = build.get_revision()
-                if building_sha == current_sha:
+                if build_sha == current_sha:
+                    commit = self.current.last_commit
+                    preset_statuses = self.iter_preset_statuses(
+                        contextes, build,
+                    )
+                    for status in preset_statuses:
+                        logger.info(
+                            "Preset pending status for %s.", status['context'],
+                        )
+                        commit.maybe_update_status(status)
+                        yield from switch_coro()
                     continue
 
-                commit = Commit(
-                    self.current.head.repository,
-                    building_sha,
-                )
-                status = CommitStatus(
-                    context=job.name,
-                    target_url=build._data['url'],
-                    state='pending',
-                )
+                commit = Commit(self.current.head.repository, build_sha)
+                status = CommitStatus(context=job.name).from_build(build)
                 logger.info("Queuing %s for cancel.", build)
                 self.current.cancel_queue.append((commit, status))
 

--- a/jenkins_epo/extensions/jenkins.py
+++ b/jenkins_epo/extensions/jenkins.py
@@ -236,11 +236,6 @@ class CancellerExtension(JenkinsExtension):
 
             commit.maybe_update_status(new_status)
 
-        payload = yield from self.current.last_commit.fetch_statuses()
-        self.current.statuses = (
-            self.current.last_commit.process_statuses(payload)
-        )
-
 
 class CreateJobsExtension(JenkinsExtension):
     """

--- a/jenkins_epo/extensions/jenkins.py
+++ b/jenkins_epo/extensions/jenkins.py
@@ -69,13 +69,6 @@ class BuilderExtension(JenkinsExtension):
             logger.info("Retrying jobs failed before %s.", instruction.date)
             self.current.rebuild_failed = instruction.date
 
-    def is_queue_empty(self):
-        if self.current.SETTINGS.ALWAYS_QUEUE:
-            logger.debug("Ignoring queue status. New jobs will be queued.")
-            return True
-
-        return JENKINS.is_queue_empty()
-
     @asyncio.coroutine
     def run(self):
         for spec in self.current.job_specs.values():
@@ -85,7 +78,7 @@ class BuilderExtension(JenkinsExtension):
                 job.list_contexts(spec),
                 rebuild_failed=self.current.rebuild_failed
             )
-            queue_empty = self.is_queue_empty()
+            queue_empty = JENKINS.is_queue_empty()
             toqueue_contexts = []
             for context in not_built:
                 logger.debug("Computing new status for %s.", spec)

--- a/jenkins_epo/jenkins.py
+++ b/jenkins_epo/jenkins.py
@@ -116,7 +116,7 @@ class LazyJenkins(object):
             i for i in data['items']
             if not i['stuck'] and match(i['task']['name'], self.queue_patterns)
         ]
-        return len(items) == 0
+        return len(items) <= SETTINGS.QUEUE_MAX
 
     @retry
     def get_job(self, name):

--- a/jenkins_epo/repository.py
+++ b/jenkins_epo/repository.py
@@ -100,13 +100,14 @@ class CommitStatus(dict):
         'FAILURE': ('failure', 'Build %(name)s failed in %(duration)s!'),
         'UNSTABLE': ('failure', 'Build %(name)s failed in %(duration)s!'),
         'SUCCESS': ('success', 'Build %(name)s succeeded in %(duration)s!'),
+        None: ('pending', 'Build %(name)s in progress...'),
     }
 
     def from_build(self, build=None):
         # If no build found, this may be an old CI build, or any other
         # unconfirmed build. Retrigger.
         jenkins_status = build.get_status() if build else 'ABORTED'
-        if build and jenkins_status:
+        if build and jenkins_status in self.jenkins_status_map:
             state, description = self.jenkins_status_map[jenkins_status]
             if description != 'Backed':
                 description = description % dict(

--- a/jenkins_epo/settings.py
+++ b/jenkins_epo/settings.py
@@ -46,7 +46,8 @@ class EnvironmentSettings(Bunch):
 
 
 DEFAULTS = {
-    'ALWAYS_QUEUE': False,
+    # Max item count in queue to enqueue new.
+    'QUEUE_MAX': 0,
     'CACHE_PATH': '.epo-cache',
     'CACHE_LIFE': 30,
     # Size of worker pool

--- a/tests/extensions/test_create_jobs.py
+++ b/tests/extensions/test_create_jobs.py
@@ -66,15 +66,19 @@ def test_yml_invalid(mocker, SETTINGS):
 @asyncio.coroutine
 def test_yml_found(mocker, SETTINGS):
     GITHUB = mocker.patch('jenkins_epo.extensions.core.GITHUB')
+    Job = mocker.patch('jenkins_epo.extensions.core.Job')
     from jenkins_epo.extensions.core import YamlExtension
 
+    Job.jobs_filter = ['*', '-skip']
     SETTINGS.update(YamlExtension.SETTINGS)
 
     ext = YamlExtension('ext', Mock())
     ext.current = ext.bot.current
     ext.current.yaml = {'job': dict()}
 
-    GITHUB.fetch_file_contents = CoroutineMock(return_value="job: command")
+    GITHUB.fetch_file_contents = CoroutineMock(
+        return_value="job: command\nskip: command",
+    )
 
     head = ext.current.head
     head.repository.url = 'https://github.com/owner/repo.git'
@@ -84,6 +88,7 @@ def test_yml_found(mocker, SETTINGS):
 
     assert GITHUB.fetch_file_contents.mock_calls
     assert 'job' in ext.current.job_specs
+    assert 'skip' not in ext.current.job_specs
 
 
 def test_yml_comment_dict():

--- a/tests/extensions/test_jenkins.py
+++ b/tests/extensions/test_jenkins.py
@@ -190,6 +190,7 @@ def test_poll_build_running(mocker):
 
     build = JENKINS.get_build_from_url.return_value
     build.get_status.return_value = None
+    build._data = {'duration': 0, 'displayName': '#6'}
 
     yield from ext.run()
 

--- a/tests/extensions/test_jenkins.py
+++ b/tests/extensions/test_jenkins.py
@@ -45,7 +45,6 @@ def test_build_queue_full(mocker):
     job = Mock()
     spec = Mock(config=dict())
     spec.name = 'job'
-    ext.current.SETTINGS.ALWAYS_QUEUE = False
     ext.current.head.ref = 'refs/heads/pr'
     ext.current.last_commit.filter_not_built_contexts.return_value = ['job']
     ext.current.jobs_match = []
@@ -72,7 +71,6 @@ def test_build_queue_empty(mocker):
     job = Mock()
     spec = Mock(config=dict())
     spec.name = 'job'
-    ext.current.SETTINGS.ALWAYS_QUEUE = False
     ext.current.head.ref = 'refs/heads/pr'
     ext.current.last_commit.filter_not_built_contexts.return_value = ['job']
     ext.current.last_commit.maybe_update_status.return_value = {


### PR DESCRIPTION
Jenkins set GitHub status of matrix job for regular (child) job only, not master fly weight job.There is no queue for flyweight job (by design). This let GitHub and EPO without build id of a master build while child jobs are in the queue… leading to eternal requeuing of the job.

This appear too when any job is cloning. Jenkins wait for the clone to complete before setting GitHub status.

Thix fix is to use the build polling of autocancel to preset the build status in GitHub as soon as the build is effective. This is best effort.